### PR TITLE
Delete sdn pods in openshift-sdn pods during migration of SDN plugins

### DIFF
--- a/roles/openshift_network_plugin/tasks/nodes.yaml
+++ b/roles/openshift_network_plugin/tasks/nodes.yaml
@@ -15,6 +15,7 @@
 - name: restart OpenShift SDN on all masters and nodes
   shell: oc delete pod --all -n openshift-sdn
   run_once: true
+  when: "'3.10' in openshift_master_version or '3.11' in openshift_master_version"
 
 - import_role:
     name: common

--- a/roles/openshift_network_plugin/tasks/nodes.yaml
+++ b/roles/openshift_network_plugin/tasks/nodes.yaml
@@ -8,7 +8,14 @@
     backup: yes
   with_items: '{{ openshift_network_plugin_node_config }}'
 
+- import_role:
+    name: common
+    tasks_from: stop-node.yaml
+
+- name: restart OpenShift SDN on all masters and nodes
+  shell: oc delete pod --all -n openshift-sdn
+  run_once: true
 
 - import_role:
     name: common
-    tasks_from: restart-node.yaml
+    tasks_from: start-node.yaml


### PR DESCRIPTION
in 3.10 and 3.11, we need to delete the pods in the openshift-sdn project.

See https://docs.openshift.com/container-platform/3.10/install_config/configuring_sdn.html#migrating-between-sdn-plugins
